### PR TITLE
Lazy evaluation and no segmentation fault when reading str arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,10 @@ notifications:
 
 matrix:
   include:
-  - python: 2.6
   - python: 2.7
     env: H5PY_VERSION="=2.3"
-  - python: 3.3
   - python: 3.4
+  - python: 3.5
   - python: 2.7
     env: H5PY_VERSION="=2.1"
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,10 @@ exceptions of:
 
 We simply haven't gotten around to implementing these features yet.
 
-A new feature, enabled by default, is the lazy opening of datasets. Unlike
+A new feature is the lazy opening of datasets. Unlike
 the netCDF interface where attributes for all variables and groups are read at
 the creation of the Dataset object, h5netcdf loads these attributes only
-when accessed. Passing `--lazy=False` to `h5netcdf.File` or `h5netcdf.legacyapi.Dataset`
-reverts to the netCDF interface behavior.
+when accessed.
 
 New API
 ~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -62,10 +62,14 @@ exceptions of:
 
 We simply haven't gotten around to implementing these features yet.
 
+ChangeLog
+---------
+
 A new feature is the lazy opening of datasets. Unlike
 the netCDF interface where attributes for all variables and groups are read at
 the creation of the Dataset object, h5netcdf loads these attributes only
 when accessed.
+
 
 New API
 ~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,12 @@ exceptions of:
 
 We simply haven't gotten around to implementing these features yet.
 
+A new feature, enabled by default, is the lazy opening of datasets. Unlike
+the netCDF interface where attributes for all variables and groups are read at
+the creation of the Dataset object, h5netcdf loads these attributes only
+when accessed. Passing `--lazy=False` to `h5netcdf.File` or `h5netcdf.legacyapi.Dataset`
+reverts to the netCDF interface behavior.
+
 New API
 ~~~~~~~
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -294,7 +294,7 @@ class Group(Mapping):
                                             **kwargs)
 
         self._variables.set(h5name,self._variable_cls(self, h5name, dimensions))
-        variable=self._variables[name]
+        variable=self._variables[h5name]
 
         if fillvalue is not None:
             value = variable.dtype.type(fillvalue)

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -154,7 +154,7 @@ class lazy_objects(Mapping):
 
     def __getitem__(self, key):
         if not key in self._objects:
-            raise KeyError('Object {0} is not avaialble.'.format(key))
+            raise KeyError(key)
         elif key in self._loaded_objects.keys():
             return self._loaded_objects[key]
         else:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -143,6 +143,9 @@ class lazy_objects():
         self._loaded_objects[name]=object
         self._objects[name]=name
 
+    def keys(self):
+        return self._objects.keys()
+
     def __iter__(self):
         for name in self._objects:
             yield name

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -159,7 +159,7 @@ class _object_names(Mapping):
         elif key in self._loaded_objects:
             return self._loaded_objects[key]
         else:
-            self._loaded_objects[key] = self._object_cls(self._parent,key)
+            self._loaded_objects[key] = self._object_cls(self._parent, key)
             return self[key]
 
 class Group(Mapping):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -15,12 +15,15 @@ def _reverse_dict(dict_):
     return dict(zip(dict_.values(), dict_.keys()))
 
 
+def _join_h5paths(parent_path, child_path):
+    return '/'.join([parent_path.rstrip('/'), child_path.lstrip('/')])
+
 class BaseVariable(object):
 
     def __init__(self, parent, name, dimensions=None):
         self._parent = parent
         self._root = parent._root
-        self._h5path = '/'.join([parent.name.rstrip('/'), name.lstrip('/')])
+        self._h5path = _join_h5paths(parent.name, name)
         self._dimensions = dimensions
         self._initialized = True
 
@@ -169,7 +172,7 @@ class Group(Mapping):
     def __init__(self, parent, name):
         self._parent = parent
         self._root = parent._root
-        self._h5path = '/'.join([parent.name.rstrip('/'), name.lstrip('/')])
+        self._h5path = _join_h5paths(parent.name, name)
 
         if parent is not self:
             self._dim_sizes = parent._dim_sizes.new_child()

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -137,16 +137,13 @@ class lazy_objects(Mapping):
         self._objects = list()
         self._loaded_objects = dict()
         self._object_cls = object_cls
-        return
 
     def set(self, name, object):
         self._objects.append(name)
         self._loaded_objects[name] = object
-        return
 
     def add(self, name):
         self._objects.append(name)
-        return
 
     def __iter__(self):
         for name in self._objects:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -132,7 +132,7 @@ class Variable(BaseVariable):
 
 NOT_A_VARIABLE = b'This is a netCDF dimension but not a netCDF variable.'
 
-class _object_names(Mapping):
+class _LazyObjectLookup(Mapping):
     def __init__(self, parent, object_cls):
         self._parent = parent
         self._object_cls = object_cls
@@ -179,8 +179,8 @@ class Group(Mapping):
             self._dim_sizes = parent._dim_sizes.new_child()
             self._dim_order = parent._dim_order.new_child()
 
-        self._variables = _object_names(self, self._variable_cls)
-        self._groups = _object_names(self, self._group_cls)
+        self._variables = _LazyObjectLookup(self, self._variable_cls)
+        self._groups = _LazyObjectLookup(self, self._group_cls)
 
         for k, v in self._h5group.items():
             if isinstance(v, h5py.Group):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -250,12 +250,12 @@ class Group(Mapping):
             raise ValueError('unable to create group %r (name already exists)'
                              % name)
         h5group = self._h5group.create_group(name)
-        self._groups.set(name,h5group)
+        self._groups.set(name,self._group_cls(self,name))
         return self._groups[name]
 
     def _require_child_group(self, name):
         try:
-            return self.groups[name]
+            return self._groups[name]
         except KeyError:
             return self._create_child_group(name)
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -140,10 +140,11 @@ class lazy_objects(Mapping):
         return
 
     def set(self, name, object):
-        self._loaded_objects[name] = object
         self._objects.append(name)
+        self._loaded_objects[name] = object
+        return
 
-    def add(self, name)
+    def add(self, name):
         self._objects.append(name)
         return
 
@@ -155,7 +156,9 @@ class lazy_objects(Mapping):
         return len(self._objects)
 
     def __getitem__(self, key):
-        if key in self._loaded_objects.keys():
+        if not key in self._objects:
+            raise KeyError('Object {0} is not avaialble.'.format(key))
+        elif key in self._loaded_objects.keys():
             return self._loaded_objects[key]
         else:
             self._loaded_objects[key] = self._object_cls(key)

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -414,7 +414,7 @@ class Group(Mapping):
 
 class File(Group):
 
-    def __init__(self, path, mode='a',lazy=False, **kwargs):
+    def __init__(self, path, mode='a',lazy=True, **kwargs):
         self._h5file = h5py.File(path, mode, **kwargs)
         self._dim_sizes = ChainMap()
         self._dim_order = ChainMap()

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -140,11 +140,11 @@ class _object_names(Mapping):
         self._loaded_objects = dict()
 
     def __setitem__(self, name, object):
-        self._objects.append(name)
+        self._objects.add(name)
         self._loaded_objects[name] = object
 
     def add(self, name):
-        self._objects.append(name)
+        self._objects.add(name)
 
     def __iter__(self):
         for name in self._objects:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -152,7 +152,7 @@ class _LazyObjectLookup(Mapping):
         return len(self._objects)
 
     def __getitem__(self, key):
-        if self._obecjts[key] != None:
+        if self._objects[key] != None:
             return self._objects[key]
         else:
             self._objects[key] = self._object_cls(self._parent, key)

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -5,7 +5,7 @@ from collections import Mapping
 import h5py
 import numpy as np
 
-from .compat import ChainMap
+from .compat import ChainMap, OrderedDict
 from .attrs import Attributes
 from .dimensions import Dimensions
 from .utils import Frozen
@@ -26,8 +26,8 @@ class BaseVariable(object):
 
     @property
     def _h5ds(self):
-        #Always refer to the root file and store not h5py object
-        #subclasses:
+        # Always refer to the root file and store not h5py object
+        # subclasses:
         return self._root._h5file[self._h5path]
 
     @property
@@ -136,15 +136,13 @@ class _LazyObjectLookup(Mapping):
     def __init__(self, parent, object_cls):
         self._parent = parent
         self._object_cls = object_cls
-        self._objects = set()
-        self._loaded_objects = dict()
+        self._objects = OrderedDict()
 
     def __setitem__(self, name, object):
-        self._objects.add(name)
-        self._loaded_objects[name] = object
+        self._objects[name] = object
 
     def add(self, name):
-        self._objects.add(name)
+        self._objects[name]=None
 
     def __iter__(self):
         for name in self._objects:
@@ -154,13 +152,11 @@ class _LazyObjectLookup(Mapping):
         return len(self._objects)
 
     def __getitem__(self, key):
-        if not key in self._objects:
-            raise KeyError(key)
-        elif key in self._loaded_objects:
-            return self._loaded_objects[key]
+        if self._obecjts[key] != None:
+            return self._objects[key]
         else:
-            self._loaded_objects[key] = self._object_cls(self._parent, key)
-            return self[key]
+            self._objects[key] = self._object_cls(self._parent, key)
+            return self._objects[key]
 
 class Group(Mapping):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -294,11 +294,11 @@ class Group(Mapping):
                                             **kwargs)
 
         self._variables.set(h5name,self._variable_cls(self, h5name, dimensions))
+        variable=self._variables[name]
 
         if fillvalue is not None:
             value = variable.dtype.type(fillvalue)
             variable.attrs._h5attrs['_FillValue'] = value
-        self._variables[name] = variable
         return variable
 
     def create_variable(self, name, dimensions=(), dtype=None, data=None,

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -147,6 +147,9 @@ class lazy_objects():
         for name in self._objects:
             yield name
 
+    def __len__(self):
+        return len(self._objects)
+
     def __setitem__(self,key,value):
         self._objects[key]=value
         return

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -134,7 +134,7 @@ NOT_A_VARIABLE = b'This is a netCDF dimension but not a netCDF variable.'
 
 class lazy_objects(Mapping):
     def __init__(self, object_cls):
-        self._objects = list()
+        self._objects = set()
         self._loaded_objects = dict()
         self._object_cls = object_cls
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -5,7 +5,7 @@ from collections import Mapping
 import h5py
 import numpy as np
 
-from .compat import ChainMap, OrderedDict
+from .compat import ChainMap
 from .attrs import Attributes
 from .dimensions import Dimensions
 from .utils import Frozen

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -138,8 +138,8 @@ class _LazyObjectLookup(Mapping):
         self._object_cls = object_cls
         self._objects = OrderedDict()
 
-    def __setitem__(self, name, object):
-        self._objects[name] = object
+    def __setitem__(self, name, obj):
+        self._objects[name] = obj
 
     def add(self, name):
         self._objects[name] = None
@@ -152,7 +152,7 @@ class _LazyObjectLookup(Mapping):
         return len(self._objects)
 
     def __getitem__(self, key):
-        if self._objects[key] != None:
+        if self._objects[key] is not None:
             return self._objects[key]
         else:
             self._objects[key] = self._object_cls(self._parent, key)

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -138,7 +138,7 @@ class lazy_objects(Mapping):
         self._loaded_objects = dict()
         self._object_cls = object_cls
 
-    def set(self, name, object):
+    def __setitem__(self, name, object):
         self._objects.append(name)
         self._loaded_objects[name] = object
 
@@ -244,7 +244,7 @@ class Group(Mapping):
             raise ValueError('unable to create group %r (name already exists)'
                              % name)
         self._h5group.create_group(name)
-        self._groups.set(name, self._group_cls(self, name))
+        self._groups[name] = self._group_cls(self, name)
         return self._groups[name]
 
     def _require_child_group(self, name):
@@ -287,7 +287,7 @@ class Group(Mapping):
                                      data=data, fillvalue=fillvalue,
                                      **kwargs)
 
-        self._variables.set(h5name, self._variable_cls(self, h5name, dimensions))
+        self._variables[h5name] = self._variable_cls(self, h5name, dimensions)
         variable = self._variables[h5name]
 
         if fillvalue is not None:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -142,7 +142,7 @@ class _LazyObjectLookup(Mapping):
         self._objects[name] = object
 
     def add(self, name):
-        self._objects[name]=None
+        self._objects[name] = None
 
     def __iter__(self):
         for name in self._objects:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -204,8 +204,8 @@ class Group(Mapping):
 
     @property
     def _h5group(self):
-        #Always refer to the root file and store not h5py object
-        #subclasses:
+        # Always refer to the root file and store not h5py object
+        # subclasses:
         return self._root._h5file[self._h5path]
 
     @property

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -155,7 +155,7 @@ class lazy_objects(Mapping):
     def __getitem__(self, key):
         if not key in self._objects:
             raise KeyError(key)
-        elif key in self._loaded_objects.keys():
+        elif key in self._loaded_objects:
             return self._loaded_objects[key]
         else:
             self._loaded_objects[key] = self._object_cls(key)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -41,10 +41,10 @@ def array_equal(a, b):
 _char_array = string_to_char(np.array(['a', 'b', 'c', 'foo', 'bar', 'baz'],
                                       dtype='S'))
 
-_string_array=np.array([['foobar0','foobar1','foobar3'],
-                     ['foofoofoo','foofoobar','foobarbar']])
+_string_array = np.array([['foobar0', 'foobar1', 'foobar3'],
+                          ['foofoofoo', 'foofoobar', 'foobarbar']])
 
-def is_h5py_char_working(tmp_netcdf,name):
+def is_h5py_char_working(tmp_netcdf, name):
     #https://github.com/Unidata/netcdf-c/issues/298
     with h5py.File(tmp_netcdf, 'r') as ds:
         v = ds[name]
@@ -52,7 +52,7 @@ def is_h5py_char_working(tmp_netcdf,name):
             assert array_equal(v, _char_array)
             return True
         except OSError as e:
-            if e.args[0]=="Can't read data (No appropriate function for conversion path)":
+            if e.args[0] == "Can't read data (No appropriate function for conversion path)":
                 return False
             else:
                 raise
@@ -178,7 +178,7 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
     ds.close()
 
     #Check the behavior if h5py. Cannot expect h5netcdf to overcome these errors:
-    if is_h5py_char_working(tmp_netcdf,'z'):
+    if is_h5py_char_working(tmp_netcdf, 'z'):
         ds = read_module.Dataset(tmp_netcdf, 'r')
         v = ds.variables['z']
         assert array_equal(v, _char_array)
@@ -263,7 +263,7 @@ def read_h5netcdf(tmp_netcdf, write_module):
     assert not v.shuffle
     ds.close()
 
-    if is_h5py_char_working(tmp_netcdf,'z'):
+    if is_h5py_char_working(tmp_netcdf, 'z'):
         ds = h5netcdf.File(tmp_netcdf, 'r')
         v = ds['z']
         assert v.dtype == 'S1'
@@ -457,14 +457,14 @@ def test_hierarchical_access_auto_create(tmp_netcdf):
 
 def test_reading_str_array_from_netCDF4(tmp_netcdf):
     #This tests reading string variables created by netCDF4
-    with netCDF4.Dataset(tmp_netcdf,'w') as ds:
-        ds.createDimension('foo1',_string_array.shape[0])
-        ds.createDimension('foo2',_string_array.shape[1])
-        ds.createVariable('bar',str,('foo1','foo2'))
-        ds.variables['bar'][:]=_string_array
+    with netCDF4.Dataset(tmp_netcdf, 'w') as ds:
+        ds.createDimension('foo1', _string_array.shape[0])
+        ds.createDimension('foo2', _string_array.shape[1])
+        ds.createVariable('bar', str, ('foo1', 'foo2'))
+        ds.variables['bar'][:] = _string_array
 
     ds = h5netcdf.File(tmp_netcdf, 'r')
 
-    v=ds.variables['bar']
-    assert array_equal(v,_string_array)
+    v = ds.variables['bar']
+    assert array_equal(v, _string_array)
     ds.close()

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -45,7 +45,7 @@ _string_array = np.array([['foobar0', 'foobar1', 'foobar3'],
                           ['foofoofoo', 'foofoobar', 'foobarbar']])
 
 def is_h5py_char_working(tmp_netcdf, name):
-    #https://github.com/Unidata/netcdf-c/issues/298
+    # https://github.com/Unidata/netcdf-c/issues/298
     with h5py.File(tmp_netcdf, 'r') as ds:
         v = ds[name]
         try:

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -126,7 +126,9 @@ def write_h5netcdf(tmp_netcdf):
 
 def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
     ds = read_module.Dataset(tmp_netcdf, 'r')
-    assert ds.ncattrs() == ['global', 'other_attr']
+    # ignore _NCProperties for now: https://github.com/shoyer/h5netcdf/issues/18
+    attr_names = [k for k in ds.ncattrs() if k != '_NCProperties']
+    assert attr_names == ['global', 'other_attr']
     assert ds.getncattr('global') == 42
     if not PY2 and write_module is not netCDF4:
         # skip for now: https://github.com/Unidata/netcdf4-python/issues/388
@@ -199,7 +201,9 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
 def read_h5netcdf(tmp_netcdf, write_module):
     ds = h5netcdf.File(tmp_netcdf, 'r')
     assert ds.name == '/'
-    assert list(ds.attrs) == ['global', 'other_attr']
+    # ignore _NCProperties for now: https://github.com/shoyer/h5netcdf/issues/18
+    attr_names = [k for k in list(ds.attrs) if k != '_NCProperties']
+    assert attr_names == ['global', 'other_attr']
     assert ds.attrs['global'] == 42
     if not PY2 and write_module is not netCDF4:
         # skip for now: https://github.com/Unidata/netcdf4-python/issues/388

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -431,12 +431,15 @@ def test_hierarchical_access_auto_create(tmp_netcdf):
     ds.close()
 
 def test_reading_str_array_from_netcdf4(tmp_netcdf):
+    test_array=['foobar0','foobar1']
     with netCDF4.Dataset(tmp_netcdf,'w') as ds:
         ds.createDimension('foo',2)
         ds.createVariable('bar',str,('foo',))
-        ds.variables['bar'][0]='foobar0'
-        ds.variables['bar'][1]='foobar1'
+        for id, val in enumerate(test_array):
+            ds.variables['bar'][id]=val
 
     ds = h5netcdf.File(tmp_netcdf, 'r')
-    assert np.array_equal(ds.variables['bar'][:],['foobar0','foobar1'])
+
+    read_array=[ds.variables['bar'][id] for id in range(len(ds.variables['bar']))]
+    assert np.array_equal(read_array,test_array)
     ds.close()

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -43,7 +43,7 @@ _char_array = string_to_char(np.array(['a', 'b', 'c', 'foo', 'bar', 'baz'],
 
 
 def write_legacy_netcdf(tmp_netcdf, write_module):
-    ds = write_module.Dataset(tmp_netcdf, 'w',lazy=True)
+    ds = write_module.Dataset(tmp_netcdf, 'w')
     ds.setncattr('global', 42)
     ds.other_attr = 'yes'
     ds.createDimension('x', 4)
@@ -86,7 +86,7 @@ def write_legacy_netcdf(tmp_netcdf, write_module):
 
 
 def write_h5netcdf(tmp_netcdf):
-    ds = h5netcdf.File(tmp_netcdf, 'w',lazy=True)
+    ds = h5netcdf.File(tmp_netcdf, 'w')
     ds.attrs['global'] = 42
     ds.attrs['other_attr'] = 'yes'
     ds.dimensions = {'x': 4, 'y': 5, 'z': 6}
@@ -125,7 +125,7 @@ def write_h5netcdf(tmp_netcdf):
 
 
 def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
-    ds = read_module.Dataset(tmp_netcdf, 'r',lazy=True)
+    ds = read_module.Dataset(tmp_netcdf, 'r')
     # ignore _NCProperties for now: https://github.com/shoyer/h5netcdf/issues/18
     attr_names = [k for k in ds.ncattrs() if k != '_NCProperties']
     assert attr_names == ['global', 'other_attr']
@@ -199,7 +199,7 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
 
 
 def read_h5netcdf(tmp_netcdf, write_module):
-    ds = h5netcdf.File(tmp_netcdf, 'r',lazy=True)
+    ds = h5netcdf.File(tmp_netcdf, 'r')
     assert ds.name == '/'
     # ignore _NCProperties for now: https://github.com/shoyer/h5netcdf/issues/18
     attr_names = [k for k in list(ds.attrs) if k != '_NCProperties']
@@ -326,7 +326,7 @@ def test_write_legacyapi_read_h5netcdf(tmp_netcdf):
 
 def test_repr(tmp_netcdf):
     write_h5netcdf(tmp_netcdf)
-    f = h5netcdf.File(tmp_netcdf, 'r',lazy=True)
+    f = h5netcdf.File(tmp_netcdf, 'r')
     assert 'h5netcdf.File' in repr(f)
     assert 'subgroup' in repr(f)
     assert 'foo' in repr(f)
@@ -356,13 +356,13 @@ def test_repr(tmp_netcdf):
 
 
 def test_attrs_api(tmp_netcdf):
-    with h5netcdf.File(tmp_netcdf,lazy=True) as ds:
+    with h5netcdf.File(tmp_netcdf) as ds:
         ds.attrs['conventions'] = 'CF'
         ds.dimensions['x'] = 1
         v = ds.create_variable('x', ('x',), 'i4')
         v.attrs.update({'units': 'meters', 'foo': 'bar'})
     assert ds._closed
-    with h5netcdf.File(tmp_netcdf,lazy=True) as ds:
+    with h5netcdf.File(tmp_netcdf) as ds:
         assert len(ds.attrs) == 1
         assert dict(ds.attrs) == {'conventions': 'CF'}
         assert list(ds.attrs) == ['conventions']
@@ -372,7 +372,7 @@ def test_attrs_api(tmp_netcdf):
 
 
 def test_optional_netcdf4_attrs(tmp_netcdf):
-    with h5py.File(tmp_netcdf,lazy=True) as f:
+    with h5py.File(tmp_netcdf) as f:
         foo_data = np.arange(50).reshape(5, 10)
         f.create_dataset('foo', data=foo_data)
         f.create_dataset('x', data=np.arange(5))
@@ -381,14 +381,14 @@ def test_optional_netcdf4_attrs(tmp_netcdf):
         f['foo'].dims.create_scale(f['y'])
         f['foo'].dims[0].attach_scale(f['x'])
         f['foo'].dims[1].attach_scale(f['y'])
-    with h5netcdf.File(tmp_netcdf, 'r',lazy=True) as ds:
+    with h5netcdf.File(tmp_netcdf, 'r') as ds:
         assert ds['foo'].dimensions == ('x', 'y')
         assert ds.dimensions == {'x': 5, 'y': 10}
         assert array_equal(ds['foo'], foo_data)
 
 
 def test_error_handling(tmp_netcdf):
-    with h5netcdf.File(tmp_netcdf, 'w',lazy=True) as ds:
+    with h5netcdf.File(tmp_netcdf, 'w') as ds:
         with raises(NotImplementedError):
             ds.dimensions['x'] = None
         ds.dimensions['x'] = 1
@@ -407,17 +407,17 @@ def test_error_handling(tmp_netcdf):
 
 
 def test_invalid_netcdf4(tmp_netcdf):
-    with h5py.File(tmp_netcdf,lazy=True) as f:
+    with h5py.File(tmp_netcdf) as f:
         f.create_dataset('foo', data=np.arange(5))
         # labeled dimensions but no dimension scales
         f['foo'].dims[0].label = 'x'
-    with h5netcdf.File(tmp_netcdf, 'r',lazy=True) as ds:
+    with h5netcdf.File(tmp_netcdf, 'r') as ds:
         with raises(ValueError):
             ds.variables['foo'].dimensions
 
 
 def test_hierarchical_access_auto_create(tmp_netcdf):
-    ds = h5netcdf.File(tmp_netcdf, 'w',lazy=True)
+    ds = h5netcdf.File(tmp_netcdf, 'w')
     ds.create_variable('/foo/bar', data=1)
     g = ds.create_group('foo/baz')
     g.create_variable('/foo/hello', data=2)
@@ -425,7 +425,7 @@ def test_hierarchical_access_auto_create(tmp_netcdf):
     assert set(ds['foo']) == set(['bar', 'baz', 'hello'])
     ds.close()
 
-    ds = h5netcdf.File(tmp_netcdf, 'r',lazy=True)
+    ds = h5netcdf.File(tmp_netcdf, 'r')
     assert set(ds) == set(['foo'])
     assert set(ds['foo']) == set(['bar', 'baz', 'hello'])
     ds.close()
@@ -437,6 +437,6 @@ def test_reading_str_array_from_netcdf4(tmp_netcdf):
         ds.variables['bar'][0]='foobar0'
         ds.variables['bar'][1]='foobar1'
 
-    ds = h5netcdf.File(tmp_netcdf, 'r',lazy=True)
+    ds = h5netcdf.File(tmp_netcdf, 'r')
     assert np.array_equal(ds.variables['bar'][:],['foobar0','foobar1'])
     ds.close()

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -429,3 +429,14 @@ def test_hierarchical_access_auto_create(tmp_netcdf):
     assert set(ds) == set(['foo'])
     assert set(ds['foo']) == set(['bar', 'baz', 'hello'])
     ds.close()
+
+def test_reading_str_array_from_netcdf4(tmp_netcdf):
+    with netCDF4.Dataset(tmp_netcdf,'w') as ds:
+        ds.createDimension('foo',2)
+        ds.createVariable('bar',str,('foo',))
+        ds.variables['bar'][0]='foobar0'
+        ds.variables['bar'][1]='foobar1'
+
+    ds = h5netcdf.File(tmp_netcdf, 'r',lazy=True)
+    assert np.array_equal(ds.variables['bar'][:],['foobar0','foobar1'])
+    ds.close()

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='h5netcdf',
       long_description=(open('README.rst').read()
                         if os.path.exists('README.rst')
                         else ''),
-      version='0.2.2',
+      version='0.2.3rc1',
       license='BSD',
       classifiers=CLASSIFIERS,
       author='Stephan Hoyer',


### PR DESCRIPTION
A few fixes.
1) both groups and variables can be lazily evaluated and,
2) no h5py object is stored in subsequent classes. This feature was causing segmentation faults when reading arrays with str datatype.

The changes are fairly minor with only a few additions to the hidden API.