### PR TITLE
Fix missing attribute exception when writing to groups

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -379,6 +379,10 @@ class Group(Mapping):
     def parent(self):
         return self._parent
 
+    def flush(self):
+        self._root.flush()
+    sync = flush
+
     @property
     def groups(self):
         return Frozen(self._groups)

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -227,7 +227,7 @@ class Group(Mapping):
     def _create_dimension(self, name, size=None):
         if name in self._dim_sizes.maps[0]:
             raise ValueError('dimension %r already exists' % name)
-        if not size:
+        if size is None:
             raise NotImplementedError('h5netcdf does not yet support '
                                       'unlimited dimensions')
         self._dim_sizes[name] = size

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -135,9 +135,11 @@ def write_h5netcdf(tmp_netcdf):
 
     g.dimensions['y'] = 10
     g.create_variable('y_var', ('y',), float)
+    g.flush()
 
     ds.dimensions['mismatched_dim'] = 1
     ds.create_variable('mismatched_dim', dtype=int)
+    ds.flush()
 
     dt = h5py.special_dtype(vlen=unicode)
     v = ds.create_variable('var_len_str', ('x',), dtype=dt)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -64,6 +64,7 @@ def write_legacy_netcdf(tmp_netcdf, write_module):
     ds.createDimension('x', 4)
     ds.createDimension('y', 5)
     ds.createDimension('z', 6)
+    ds.createDimension('empty', 0)
     ds.createDimension('string3', 3)
 
     v = ds.createVariable('foo', float, ('x', 'y'), chunksizes=(4, 5),
@@ -107,7 +108,7 @@ def write_h5netcdf(tmp_netcdf):
     ds = h5netcdf.File(tmp_netcdf, 'w')
     ds.attrs['global'] = 42
     ds.attrs['other_attr'] = 'yes'
-    ds.dimensions = {'x': 4, 'y': 5, 'z': 6}
+    ds.dimensions = {'x': 4, 'y': 5, 'z': 6, 'empty': 0}
 
     v = ds.create_variable('foo', ('x', 'y'), float, chunks=(4, 5),
                            compression='gzip', shuffle=True)
@@ -155,7 +156,8 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
     if not PY2 and write_module is not netCDF4:
         # skip for now: https://github.com/Unidata/netcdf4-python/issues/388
         assert ds.other_attr == 'yes'
-    assert set(ds.dimensions) == set(['x', 'y', 'z', 'string3', 'mismatched_dim'])
+    assert set(ds.dimensions) == set(['x', 'y', 'z', 'empty', 'string3',
+                                      'mismatched_dim'])
     assert set(ds.variables) == set(['foo', 'y', 'z', 'intscalar', 'scalar',
                                      'var_len_str', 'mismatched_dim'])
     assert set(ds.groups) == set(['subgroup'])
@@ -239,7 +241,7 @@ def read_h5netcdf(tmp_netcdf, write_module):
     if not PY2 and write_module is not netCDF4:
         # skip for now: https://github.com/Unidata/netcdf4-python/issues/388
         assert ds.attrs['other_attr'] == 'yes'
-    assert set(ds.dimensions) == set(['x', 'y', 'z', 'string3', 'mismatched_dim'])
+    assert set(ds.dimensions) == set(['x', 'y', 'z', 'empty', 'string3', 'mismatched_dim'])
     assert set(ds.variables) == set(['foo', 'y', 'z', 'intscalar', 'scalar',
                                      'var_len_str', 'mismatched_dim'])
     assert set(ds.groups) == set(['subgroup'])


### PR DESCRIPTION
See: pydata/xarray#994.

I also made a small change in `core.Group._create_dimension` when checking for unlimited dimensions: presently this throws an exception when `size=0`, which seems incorrect.