### PR TITLE
Include tests to the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include *.py


### PR DESCRIPTION
The current tarball hosted on PyPI is missing the test suite associated with the package. I added it manually to the source of the [Debian package](https://packages.debian.org/source/sid/python-h5netcdf), but it would be better if they were systematically included in future releases on PyPI, hence this PR.