### PR TITLE
Warnings when using invalid netCDF features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   - python: 2.7
   - python: 3.4
   - python: 3.5
+  - python: 3.6
   - python: 2.7
     env: H5PY_VERSION="=2.1"
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -45,11 +45,11 @@ Usage
 -----
 
 h5netcdf has two APIs, a new API and a legacy API. Both interfaces currently
-reproduce most of the features of the netCDF interface, with the noteable
+reproduce most of the features of the netCDF interface, with the notable
 exceptions of:
 
 - support for operations the rename or delete existing objects.
-- suport for creating unlimited dimensions.
+- support for creating unlimited dimensions.
 
 We simply haven't gotten around to implementing these features yet. Patches
 would be very welcome.
@@ -120,22 +120,64 @@ exact match. Here is an incomplete list of functionality we don't include:
 
 - Utility functions ``chartostring``, ``num2date``, etc., that are not directly necessary
   for writing netCDF files.
-- We don't support the ``endian`` argument to ``createVariable``. The h5py API does not
-  appear to offer this feature.
+- We don't support the ``endian`` argument to ``createVariable`` yet (see `GitHub issue`_).
 - h5netcdf variables do not support automatic masking or scaling (e.g., of values matching
   the ``_FillValue`` attribute). We prefer to leave this functionality to client libraries
   (e.g., xarray_), which can implement their exact desired scaling behavior.
 
+.. _GitHub issue: https://github.com/shoyer/h5netcdf/issues/15
+
+Invalid netCDF files
+~~~~~~~~~~~~~~~~~~~~
+
+h5py implements some features that do not (yet) result in valid netCDF files:
+
+- Data types:
+    - Booleans
+    - Complex values
+    - Non-string variable length types
+    - Enum types
+    - Reference types
+- Compression algorithms:
+    - Algorithms other than gzip
+    - Scale-offset filters
+
+By default, h5netcdf does not allow writing files using any of these features,
+as files with such features are not readable by other netCDF tools.
+(For backwards compatibility, this is currently only a warning, but in h5netcdf
+v0.5 we will raise ``h5netcdf.CompatibilityError``. Use ``invalid_netcdf=False``
+to switch to the new behavior.)
+
+However, these are still valid HDF5 files. If you don't care about netCDF
+compatibility, you can use these features by setting ``invalid_netcdf=True``
+when creating a file:
+
+.. code-block:: python
+
+  # avoid the .nc extension for non-netcdf files
+  f = h5netcdf.File('mydata.h5', invalid_netcdf=True)
+  ...
+
+  # works with the legacy API, too, though compression options are not exposed
+  ds = h5netcdf.legacyapi.Dataset('mydata.h5', invalid_netcdf=True)
+  ...
+
 Change Log
 ----------
 
-Version 0.3.1:
+Version 0.4 (Aug 29, 2017):
+
+- Add ``invalid_netcdf`` argument. Warnings are now issued by default when
+  writing an invalid NetCDF file. See the "Invalid netCDF files" section of the
+  README for full details.
+
+Version 0.3.1 (Sep 2, 2016):
 
 - Fix garbage collection issue.
 - Add missing ``.flush()`` method for groups.
 - Allow creating dimensions of size 0.
 
-Version 0.3.0:
+Version 0.3.0 (Aug 7, 2016):
 
 - Datasets are now loaded lazily. This should increase performance when opening
   files with a large number of groups and/or variables.

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ when creating a file:
 Change Log
 ----------
 
-Version 0.4 (Aug 29, 2017):
+Version 0.4 (Aug 30, 2017):
 
 - Add ``invalid_netcdf`` argument. Warnings are now issued by default when
   writing an invalid NetCDF file. See the "Invalid netCDF files" section of the
@@ -181,9 +181,10 @@ Version 0.3.0 (Aug 7, 2016):
 
 - Datasets are now loaded lazily. This should increase performance when opening
   files with a large number of groups and/or variables.
-- Support for writing arrays of variable length unicode strings with `dtype=str`
-  via the legacy API.
-- h5netcdf now writes the _NCProperties attribute for identifying netCDF4 files.
+- Support for writing arrays of variable length unicode strings with
+  ``dtype=str`` via the legacy API.
+- h5netcdf now writes the ``_NCProperties`` attribute for identifying netCDF4
+  files.
 
 License
 -------

--- a/h5netcdf/__init__.py
+++ b/h5netcdf/__init__.py
@@ -5,4 +5,4 @@ h5netcdf
 A Python library for the netCDF4 file-format that directly reads and writes
 HDF5 files via h5py, without using the Unidata netCDF library.
 """
-from .core import File, Group, Variable, __version__
+from .core import CompatibilityError, File, Group, Variable, __version__

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -14,7 +14,7 @@ from .dimensions import Dimensions
 from .utils import Frozen
 
 
-__version__ = '0.3.2'
+__version__ = '0.4.0'
 
 
 _NC_PROPERTIES = (u'version=1|h5netcdfversion=%s|hdf5libversion=%s'

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Scientific/Engineering',
 ]
 
@@ -22,7 +23,7 @@ setup(name='h5netcdf',
       long_description=(open('README.rst').read()
                         if os.path.exists('README.rst')
                         else ''),
-      version='0.3.1',
+      version='0.4.0',
       license='BSD',
       classifiers=CLASSIFIERS,
       author='Stephan Hoyer',


### PR DESCRIPTION
Fixes #28
xref pydata/xarray#1536

New behavior:
```
In [1]: import h5netcdf

In [2]: f = h5netcdf.File('warning.h5')

In [3]: f.attrs['foo'] = 1j
/Users/shoyer/conda/envs/h5netcdf-dev/bin/ipython:1: FutureWarning: complex dtypes
are supported by h5py, but not part of the NetCDF API. You are writing an HDF5
file that is not a valid NetCDF file! In the future, this will be an error, unless
you set invalid_netcdf=True.
  #!/bin/bash /Users/shoyer/conda/envs/h5netcdf-dev/bin/python.app

In [4]: f = h5netcdf.File('error.h5', invalid_netcdf=False)

In [5]: f.attrs['foo'] = 1j
CompatibilityError: complex dtypes are not a supported NetCDF feature, and are not
allowed by h5netcdf unless invalid_netcdf=True.
```

CC @dopplershift -- I would appreciate any feedback you might have on the error/warning message and the new README.