### PR TITLE
Fixup inclusion of the tests in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE
-recursive-include *.py
+recursive-include h5netcdf/tests *.py


### PR DESCRIPTION
My mistake for not verifying my first patch before hand. The tarball for version 0.4.0 on PyPI still lacks the test suite. This commit fixes it.