### PR TITLE
Adding support for unlimited dimensions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ reproduce most of the features of the netCDF interface, with the notable
 exceptions of:
 
 - support for operations the rename or delete existing objects.
-- The legacy interface currently does not support resizing unlimited
-  dimensions. Dimensions can be manually resized in the new API with
+- The legacy interface currently does not support resizing unlimited dimensions
+  with array indexing. Dimensions can be manually resized with
   ``Group.resize(dimension, size)`` which will resize the dimension axes and
   all dependent variables.
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,10 @@ reproduce most of the features of the netCDF interface, with the notable
 exceptions of:
 
 - support for operations the rename or delete existing objects.
-- support for creating unlimited dimensions.
+- The legacy interface currently does not support resizing unlimited
+  dimensions. Variables can be manually resized in the new API with
+  ``f.variables["NAME"].resize()`` which is just a thin wrapper around
+  ``h5py``'s ``DataSet.resize()`` method.
 
 We simply haven't gotten around to implementing these features yet. Patches
 would be very welcome.

--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ exceptions of:
 
 - support for operations the rename or delete existing objects.
 - The legacy interface currently does not support resizing unlimited
-  dimensions. Variables can be manually resized in the new API with
-  ``f.variables["NAME"].resize()`` which is just a thin wrapper around
-  ``h5py``'s ``DataSet.resize()`` method.
+  dimensions. Dimensions can be manually resized in the new API with
+  ``Group.resize(dimension, size)`` which will resize the dimension axes and
+  all dependent variables.
 
 We simply haven't gotten around to implementing these features yet. Patches
 would be very welcome.

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -215,7 +215,7 @@ class Group(Mapping):
         # Flag used to determine if the current size of the unlimited
         # dimensions must be detected manually at the end of the
         # initialization.
-        _current_size_set = False
+        has_existing_unlimited_dims = False
 
         for k, v in self._h5group.items():
             if isinstance(v, h5py.Group):
@@ -236,7 +236,7 @@ class Group(Mapping):
 
                     self._dim_sizes[k] = size
                     self._current_dim_sizes[k] = current_size
-                    _current_size_set = True
+                    has_existing_unlimited_dims = True
                     if dim_id is None:
                         dim_id = len(self._dim_order)
                     self._dim_order[k] = dim_id
@@ -246,7 +246,7 @@ class Group(Mapping):
                         var_name = k[len('_nc4_non_coord_'):]
                     self._variables.add(var_name)
 
-        if _current_size_set is True:
+        if has_existing_unlimited_dims is True:
             self._determine_current_dimension_sizes()
 
         self._initialized = True

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -500,15 +500,17 @@ class Group(Mapping):
         self._dim_order[dimension] = len(self._dim_order)
 
         for var in self.variables.values():
-            try:
-                idx = var.dimensions.index(dimension)
-            except ValueError:
-                continue
-            var._h5ds.resize(size, axis=idx)
+            new_shape = list(var.shape)
+            for _i, d in enumerate(var.dimensions):
+                if d == dimension:
+                    new_shape[_i] = size
+            new_shape = tuple(new_shape)
+            if new_shape != var.shape:
+                var._h5ds.resize(new_shape)
 
         # Recurse as dimensions are visible to this group and all child groups.
-        for i in self.groups:
-            i.resize(dimension, size)
+        for i in self.groups.values():
+            i.resize_dimension(dimension, size)
 
 
 class File(Group):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -469,15 +469,19 @@ class Group(Mapping):
     _cls_name = 'h5netcdf.Group'
 
     def _repr_body(self):
-        return (['Dimensions:'] +
-                ['    %s: %s' % (k, v) for k, v in self.dimensions.items()] +
-                ['Groups:'] +
-                ['    %s' % g for g in self.groups] +
-                ['Variables:'] +
-                ['    %s: %r %s' % (k, v.dimensions, v.dtype)
-                 for k, v in self.variables.items()] +
-                ['Attributes:'] +
-                ['    %s: %r' % (k, v) for k, v in self.attrs.items()])
+        return (
+            ['Dimensions:'] +
+            ['    %s: %s' % (k, ("Unlimited (current: %s)" %
+                                 self._current_dim_sizes[k])
+                             if v is None else v)
+             for k, v in self.dimensions.items()] +
+            ['Groups:'] +
+            ['    %s' % g for g in self.groups] +
+            ['Variables:'] +
+            ['    %s: %r %s' % (k, v.dimensions, v.dtype)
+             for k, v in self.variables.items()] +
+            ['Attributes:'] +
+            ['    %s: %r' % (k, v) for k, v in self.attrs.items()])
 
     def __repr__(self):
         if self._root._closed:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -30,6 +30,12 @@ def _join_h5paths(parent_path, child_path):
     return '/'.join([parent_path.rstrip('/'), child_path.lstrip('/')])
 
 
+def _name_from_dimension(dim):
+    # First value in a dimension is the actual dimension scale
+    # which we'll use to extract the name.
+    return dim[0].name.split('/')[-1]
+
+
 class CompatibilityError(Exception):
     """Raised when using features that are not part of the NetCDF4 API."""
 
@@ -88,7 +94,7 @@ class BaseVariable(object):
                 raise ValueError('variable %r has no dimension scale '
                                  'associated with axis %s'
                                  % (self.name, axis))
-            name = dim[0].name.split('/')[-1]
+            name = _name_from_dimension(dim)
             dims.append(name)
         return tuple(dims)
 
@@ -284,9 +290,7 @@ class Group(Mapping):
                 var = root[ref]
 
                 for i, var_d in enumerate(var.dims):
-                    # First value in a dimension is the actual dimension scale
-                    # which we'll use to extract the name.
-                    name = var_d[0].name.strip("/")
+                    name = _name_from_dimension(var_d)
                     if name == d:
                         max_size = max(var.shape[i], max_size)
             self._current_dim_sizes[d] = max_size

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -267,13 +267,13 @@ class Group(Mapping):
                 return _find_dim(h5group.parent, dim)
             return h5group[dim]
 
-        for d in self.dimensions:
-            if self.dimensions[d] is not None:
+        for dim_name in self.dimensions:
+            if self.dimensions[dim_name] is not None:
                 continue
-            dim = _find_dim(self._h5group, d)
+            dim_variable = _find_dim(self._h5group, dim_name)
 
-            if "REFERENCE_LIST" not in dim.attrs:
-                if dim.shape == (0,):
+            if "REFERENCE_LIST" not in dim_variable.attrs:
+                if dim_variable.shape == (0,):
                     # NetCDF does not create the REFERENCE_LIST attribute if
                     # an unlimited dimension is of zero length. In this case it
                     # is safe to skip this dimension.
@@ -285,15 +285,15 @@ class Group(Mapping):
 
             root = self._h5group["/"]
 
-            max_size = self._current_dim_sizes[d]
-            for ref, _ in dim.attrs["REFERENCE_LIST"]:
+            max_size = self._current_dim_sizes[dim_name]
+            for ref, _ in dim_variable.attrs["REFERENCE_LIST"]:
                 var = root[ref]
 
                 for i, var_d in enumerate(var.dims):
                     name = _name_from_dimension(var_d)
-                    if name == d:
+                    if name == dim_name:
                         max_size = max(var.shape[i], max_size)
-            self._current_dim_sizes[d] = max_size
+            self._current_dim_sizes[dim_name] = max_size
 
     @property
     def _h5group(self):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -241,7 +241,7 @@ class Group(Mapping):
                     self._variables.add(var_name)
 
         # One last pass to get the current sizes. This is necessary as h5netcdf
-        # needs to now the current size of each unlimited dimension.
+        # needs to know the current size of each unlimited dimension.
         #
         # I'm not entirely sure how the netcdf C api determines the current
         # size - should probably be looked into.

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -361,10 +361,10 @@ class Group(Mapping):
         if None in shape:
             kwargs['maxshape'] = shape
             if data is None:
-                shape = tuple(_i if _i is not None else 0 for _i in shape)
+                shape = tuple(i if i is not None else 0 for i in shape)
             else:
-                shape = tuple(_j if _j is not None else data.shape[_i]
-                              for _i, _j in enumerate(shape))
+                shape = tuple(j if j is not None else i
+                              for i, j in zip(data.shape, shape))
 
         self._h5group.create_dataset(h5name, shape, dtype=dtype,
                                      data=data, fillvalue=fillvalue,

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -648,14 +648,21 @@ def test_writing_to_an_unlimited_dimension(tmp_netcdf):
         f.create_variable('dummy1', dimensions=('x', 'y'), dtype=np.int64)
         f.create_variable('dummy2', dimensions=('x', 'y'), dtype=np.int64)
         f.create_variable('dummy3', dimensions=('x', 'y'), dtype=np.int64)
+        g = f.create_group('test')
+        g.create_variable('dummy4', dimensions=('y', 'x', 'x'), dtype=np.int64)
+        g.create_variable('dummy5', dimensions=('y', 'y'), dtype=np.int64)
 
         assert f.variables['dummy1'].shape == (0, 3)
         assert f.variables['dummy2'].shape == (0, 3)
         assert f.variables['dummy3'].shape == (0, 3)
+        assert g.variables['dummy4'].shape == (3, 0, 0)
+        assert g.variables['dummy5'].shape == (3, 3)
         f.resize_dimension("x", 2)
         assert f.variables['dummy1'].shape == (2, 3)
         assert f.variables['dummy2'].shape == (2, 3)
         assert f.variables['dummy3'].shape == (2, 3)
+        assert g.variables['dummy4'].shape == (3, 2, 2)
+        assert g.variables['dummy5'].shape == (3, 3)
 
         f.variables['dummy2'][:] = [[1, 2, 3], [5, 6, 7]]
         np.testing.assert_allclose(f.variables['dummy2'],

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -583,7 +583,7 @@ def test_creating_an_unlimited_dimension(tmp_netcdf):
 
 def test_writing_to_an_unlimited_dimension(tmp_netcdf):
     with h5netcdf.File(tmp_netcdf) as f:
-        # Two dimension, only one is unlimited.
+        # Two dimensions, only one is unlimited.
         f.dimensions['x'] = None
         f.dimensions['y'] = 3
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -391,6 +391,12 @@ def test_repr(tmp_netcdf):
     assert 'h5netcdf.Variable' in repr(v)
     assert 'float' in repr(v)
     assert 'units' in repr(v)
+
+    f.dimensions['temp'] = None
+    assert 'temp: Unlimited (current: 0)' in repr(f)
+    f.resize_dimension('temp', 5)
+    assert 'temp: Unlimited (current: 5)' in repr(f)
+
     f.close()
 
     assert 'Closed' in repr(f)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -584,7 +584,8 @@ def test_creating_and_resizing_unlimited_dimensions(tmp_netcdf):
 
         with pytest.raises(ValueError) as e:
             f.resize_dimension('y', 20)
-        assert e.value.args[0] == "Only unlimited dimensions can be resized."
+        assert e.value.args[0] == (
+            "Dimension 'y' is not unlimited and thus cannot be resized.")
 
     # Assert some behavior observed by using the C netCDF bindings.
     with h5py.File(tmp_netcdf) as f:
@@ -680,7 +681,7 @@ def test_writing_to_an_unlimited_dimension(tmp_netcdf):
 
 def test_c_api_can_read_unlimited_dimensions(tmp_netcdf):
     with h5netcdf.File(tmp_netcdf) as f:
-        # Two dimensions, only one is unlimited.
+        # Three dimensions, only one is limited.
         f.dimensions['x'] = None
         f.dimensions['y'] = 3
         f.dimensions['z'] = None

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -646,10 +646,9 @@ def test_writing_to_an_unlimited_dimension(tmp_netcdf):
 
         # Cannot create it without first resizing it.
         with pytest.raises(ValueError) as e:
-                f.create_variable('dummy1', data=np.array([[1, 2, 3]]),
-                                  dimensions=('x', 'y'))
-                assert e.value.args[0] == \
-                    "Shape tuple is incompatible with data"
+            f.create_variable('dummy1', data=np.array([[1, 2, 3]]),
+                              dimensions=('x', 'y'))
+            assert e.value.args[0] == "Shape tuple is incompatible with data"
 
         # Without data.
         f.create_variable('dummy1', dimensions=('x', 'y'), dtype=np.int64)


### PR DESCRIPTION
This PR adds support for unlimited dimensions.

I'm not very familiar with netncdf but as far as I can tell the underlying HDF5 data sets are automatically resized if required so that is what I implemented here. I think I caught the most common indexing patterns.

It is tested in the sense that netcdf can open the resulting files just fine and everything appears to be correct. There is also full test coverage for all changes and this PR does not change the behavior of limited dimensions.

It would be great if this could be merged with a subsequent release fairly soon as we have a number of downstream project that depend on it and we really need unlimited dimensions. Let me know if I can help with things!