### PR TITLE
Test using the conda-forge channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - conda info -a
 
 install:
-  - conda create --yes -n test_env python=$TRAVIS_PYTHON_VERSION pip pytest h5py$H5PY_VERSION cython netCDF4
+  - conda create -c conda-forge --yes -n test_env python=$TRAVIS_PYTHON_VERSION pip pytest h5py$H5PY_VERSION cython netCDF4
   - source activate test_env
   - python setup.py install
 


### PR DESCRIPTION
It's generally more up-to-date than the default channel, e.g., for dependencies like netCDF4-python.

Note that tests are currently failing, due to https://github.com/shoyer/h5netcdf/issues/32.