### PR TITLE
Compatibility Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ notifications:
 
 matrix:
   include:
-  - env: PYTHON_VERSION=2.7
-  - env: PYTHON_VERSION=3.4
   - env: PYTHON_VERSION=3.5
   - env: PYTHON_VERSION=3.6
   - env: PYTHON_VERSION=3.7

--- a/h5netcdf/attrs.py
+++ b/h5netcdf/attrs.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import numpy as np
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1,6 +1,6 @@
 # For details on how netCDF4 builds on HDF5:
 # http://www.unidata.ucar.edu/software/netcdf/docs/file_format_specifications.html#netcdf_4_spec
-from collections import Mapping
+from collections.abc import Mapping
 import os.path
 import warnings
 

--- a/h5netcdf/dimensions.py
+++ b/h5netcdf/dimensions.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 
 class Dimensions(MutableMapping):

--- a/h5netcdf/utils.py
+++ b/h5netcdf/utils.py
@@ -1,4 +1,4 @@
-from collections import Mapping
+from collections.abc import Mapping
 
 import numpy as np
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import os
 from setuptools import setup, find_packages
+import sys
 
+if sys.version_info[:2] < (3, 5):
+    raise RuntimeError('Python version >= 3.5 required.')
 
 CLASSIFIERS = [
     'Development Status :: 4 - Beta',
@@ -8,10 +11,7 @@ CLASSIFIERS = [
     'Operating System :: OS Independent',
     'Intended Audience :: Science/Research',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
@@ -30,6 +30,7 @@ setup(name='h5netcdf',
       author='Stephan Hoyer',
       author_email='shoyer@gmail.com',
       url='https://github.com/shoyer/h5netcdf',
+      python_requires='>=3.5',
       install_requires=['h5py'],
       tests_require=['netCDF4', 'pytest'],
       packages=find_packages())


### PR DESCRIPTION
```
/home/users/me/Dev/h5netcdf/h5netcdf/dimensions.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping
```

I didn't try to keep the compatibility with Python 2.7 since we are in July 2019 (see https://python3statement.org/).