### PR TITLE
ENH: invent `phony_dim` names for unlabeled dimensions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,13 @@ to group access time. The created phony dimension naming will differ from
 
 Change Log
 ----------
+Version 0.8.0 (TBD):
+
+- Support for reading Datasets with missing dimension scales.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Fixed a bug where ``Datatype`` objects were treated as ``Datasets``.
+- Fixed several issues with upstream deprecations.
+
 Version 0.7.4 (June 1, 2019):
 
 - Fixed a flakey test on Python 2.7 and 3.4.

--- a/README.rst
+++ b/README.rst
@@ -178,7 +178,7 @@ phony dimensions according to `netCDF`_ behaviour.
 
 .. code-block:: python
 
-  # mimick netCDF-behaviour for non-netcdf files
+  # mimic netCDF-behaviour for non-netcdf files
   f = h5netcdf.File('mydata.h5', mode='r', phony_dims='sort')
   ...
 
@@ -186,7 +186,7 @@ Note, that this iterates once over the whole group-hierarchy. This has affects
 on performance in case you rely on lazyness of group access.
 You can set ``phony_dims='access'`` instead to defer phony dimension creation
 to group access time. The created phony dimension naming will differ from
-`netCDF`_ behaviour
+`netCDF`_ behaviour.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -168,9 +168,36 @@ when creating a file:
        we will raise ``h5netcdf.CompatibilityError``. Use
        ``invalid_netcdf=False`` to switch to the new behavior now.
 
+Datasets with missing dimension scales
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default [*]_ h5netcdf raises a ``ValueError`` if variables with no dimension
+scale associated with one of their axes are accessed.
+You can set ``phony_dims='sort'`` when opening a file to let h5netcdf invent
+phony dimensions according to `netCDF`_ behaviour.
+
+.. code-block:: python
+
+  # mimick netCDF-behaviour for non-netcdf files
+  f = h5netcdf.File('mydata.h5', mode='r', phony_dims='sort')
+  ...
+
+Note, that this iterates once over the whole group-hierarchy. This has affects
+on performance in case you rely on lazyness of group access.
+You can set ``phony_dims='access'`` instead to defer phony dimension creation
+to group access time. The created phony dimension naming will differ from
+`netCDF`_ behaviour
+
+.. code-block:: python
+
+  f = h5netcdf.File('mydata.h5', mode='r', phony_dims='access')
+  ...
+
+.. _netCDF: https://www.unidata.ucar.edu/software/netcdf/docs/interoperability_hdf5.html
+.. [*] Keyword default setting ``phony_dims=None`` for backwards compatibility.
+
 Change Log
 ----------
-
 Version 0.7.4 (June 1, 2019):
 
 - Fixed a flakey test on Python 2.7 and 3.4.

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -224,7 +224,10 @@ def _netcdf_dimension_but_not_variable(h5py_dataset):
 def _unlabeled_dimension_mix(h5py_dataset):
     dims = sum([len(j) for j in h5py_dataset.dims])
     if dims:
-        assert dims == h5py_dataset.ndim
+        if dims != h5py_dataset.ndim:
+            name = h5py_dataset.name.split('/')[-1]
+            raise ValueError('malformed variable %r has mixing of labeled and '
+                             'unlabeled dimensions.'.format(name))
     return dims
 
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -333,13 +333,11 @@ class Group(Mapping):
     def _create_phony_dimensions(self):
         # this is for 'sort' naming
         for key, value in self._phony_dims.items():
-            try:
+            if isinstance(value, int):
                 value += self._root._labeled_dim_count
                 name = "phony_dim_{}".format(value)
                 self._create_dimension(name, key[0])
                 self._phony_dims[key] = name
-            except TypeError:
-                pass
 
     def _determine_current_dimension_size(self, dim_name, max_size):
         """

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -518,15 +518,42 @@ def test_error_handling(tmp_local_or_remote_netcdf):
             ds.create_group('subgroup')
 
 
+def create_invalid_netcdf_data():
+    foo_data = np.arange(125).reshape(5, 5, 5)
+    bar_data = np.arange(625).reshape(25, 5, 5)
+    var = {'foo1': foo_data, 'foo2': bar_data,
+           'foo3': foo_data, 'foo4': bar_data}
+    var2 = {'x': 5, 'y': 5, 'z': 5, 'x1': 25, 'y1': 5, 'z1': 5}
+    return var, var2
+
+
+def check_invalid_netcdf4(var, i):
+    pdim = 'phony_dim_{}'
+    assert var['foo1'].dimensions[0] == pdim.format(i * 4)
+    assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
+    assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
+    assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
+    assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
+    assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
+    assert var['foo3'].dimensions[0] == pdim.format(i * 4)
+    assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
+    assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
+    assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
+    assert var['foo4'].dimensions[1] == pdim.format(i * 4)
+    assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
+    assert var['x'].dimensions[0] == pdim.format(i * 4)
+    assert var['y'].dimensions[0] == pdim.format(i * 4)
+    assert var['z'].dimensions[0] == pdim.format(i * 4)
+    assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
+    assert var['y1'].dimensions[0] == pdim.format(i * 4)
+    assert var['z1'].dimensions[0] == pdim.format(i * 4)
+
+
 def test_invalid_netcdf4(tmp_local_or_remote_netcdf):
     h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
     with h5.File(tmp_local_or_remote_netcdf, 'w') as f:
+        var, var2 = create_invalid_netcdf_data()
         grps = ['bar', 'baz']
-        foo_data = np.arange(125).reshape(5, 5, 5)
-        bar_data = np.arange(625).reshape(25, 5, 5)
-        var = {'foo1': foo_data, 'foo2': bar_data,
-               'foo3': foo_data, 'foo4': bar_data}
-        var2 = {'x': 5, 'y': 5, 'z': 5, 'x1': 25, 'y1': 5, 'z1': 5}
         for grp in grps:
             fx = f.create_group(grp)
             for k, v in var.items():
@@ -539,73 +566,21 @@ def test_invalid_netcdf4(tmp_local_or_remote_netcdf):
         i = len(grps) - 1
         for grp in grps[::-1]:
             var = dsr[grp].variables
-            pdim = 'phony_dim_{}'
-            assert var['foo1'].dimensions[0] == pdim.format(i * 4)
-            assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
-            assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
-            assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
-            assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
-            assert var['foo3'].dimensions[0] == pdim.format(i * 4)
-            assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
-            assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
-            assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['foo4'].dimensions[1] == pdim.format(i * 4)
-            assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
-            assert var['x'].dimensions[0] == pdim.format(i * 4)
-            assert var['y'].dimensions[0] == pdim.format(i * 4)
-            assert var['z'].dimensions[0] == pdim.format(i * 4)
-            assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['y1'].dimensions[0] == pdim.format(i * 4)
-            assert var['z1'].dimensions[0] == pdim.format(i * 4)
+            check_invalid_netcdf4(var, i)
             i -= 1
 
     with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
                        phony_dims='access') as dsr:
         for i, grp in enumerate(grps[::-1]):
+            print(dsr[grp])
             var = dsr[grp].variables
-            pdim = 'phony_dim_{}'
-            assert var['foo1'].dimensions[0] == pdim.format(i * 4)
-            assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
-            assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
-            assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
-            assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
-            assert var['foo3'].dimensions[0] == pdim.format(i * 4)
-            assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
-            assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
-            assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['foo4'].dimensions[1] == pdim.format(i * 4)
-            assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
-            assert var['x'].dimensions[0] == pdim.format(i * 4)
-            assert var['y'].dimensions[0] == pdim.format(i * 4)
-            assert var['z'].dimensions[0] == pdim.format(i * 4)
-            assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['y1'].dimensions[0] == pdim.format(i * 4)
-            assert var['z1'].dimensions[0] == pdim.format(i * 4)
+            check_invalid_netcdf4(var, i)
 
     with netCDF4.Dataset(tmp_local_or_remote_netcdf, mode='r') as dsr:
         for i, grp in enumerate(grps):
+            print(dsr[grp])
             var = dsr[grp].variables
-            pdim = 'phony_dim_{}'
-            assert var['foo1'].dimensions[0] == pdim.format(i * 4)
-            assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
-            assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
-            assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
-            assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
-            assert var['foo3'].dimensions[0] == pdim.format(i * 4)
-            assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
-            assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
-            assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['foo4'].dimensions[1] == pdim.format(i * 4)
-            assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
-            assert var['x'].dimensions[0] == pdim.format(i * 4)
-            assert var['y'].dimensions[0] == pdim.format(i * 4)
-            assert var['z'].dimensions[0] == pdim.format(i * 4)
-            assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
-            assert var['y1'].dimensions[0] == pdim.format(i * 4)
-            assert var['z1'].dimensions[0] == pdim.format(i * 4)
+            check_invalid_netcdf4(var, i)
 
     with h5netcdf.File(tmp_local_or_remote_netcdf, 'r') as ds:
         with raises(ValueError):
@@ -617,21 +592,36 @@ def test_invalid_netcdf4(tmp_local_or_remote_netcdf):
             pass
 
 
+def check_invalid_netcdf4_mixed(var, i):
+    pdim = 'phony_dim_{}'.format(i)
+    assert var['foo1'].dimensions[0] == 'y1'
+    assert var['foo1'].dimensions[1] == 'z1'
+    assert var['foo1'].dimensions[2] == pdim
+    assert var['foo2'].dimensions[0] == 'x1'
+    assert var['foo2'].dimensions[1] == 'y1'
+    assert var['foo2'].dimensions[2] == 'z1'
+    assert var['foo3'].dimensions[0] == 'y1'
+    assert var['foo3'].dimensions[1] == 'z1'
+    assert var['foo3'].dimensions[2] == pdim
+    assert var['foo4'].dimensions[0] == 'x1'
+    assert var['foo4'].dimensions[1] == 'y1'
+    assert var['foo4'].dimensions[2] == 'z1'
+    assert var['x'].dimensions[0] == 'y1'
+    assert var['y'].dimensions[0] == 'y1'
+    assert var['z'].dimensions[0] == 'y1'
+    assert var['x1'].dimensions[0] == 'x1'
+    assert var['y1'].dimensions[0] == 'y1'
+    assert var['z1'].dimensions[0] == 'z1'
+
+
 def test_invalid_netcdf4_mixed(tmp_local_or_remote_netcdf):
     h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
     with h5.File(tmp_local_or_remote_netcdf) as f:
-        foo_data = np.arange(125).reshape(5, 5, 5)
-        bar_data = np.arange(625).reshape(25, 5, 5)
-        f.create_dataset('foo1', data=foo_data)
-        f.create_dataset('foo2', data=bar_data)
-        f.create_dataset('foo3', data=foo_data)
-        f.create_dataset('foo4', data=bar_data)
-        f.create_dataset('x', data=np.arange(5))
-        f.create_dataset('y', data=np.arange(5))
-        f.create_dataset('z', data=np.arange(5))
-        f.create_dataset('x1', data=np.arange(25))
-        f.create_dataset('y1', data=np.arange(5))
-        f.create_dataset('z1', data=np.arange(5))
+        var, var2 = create_invalid_netcdf_data()
+        for k, v in var.items():
+            f.create_dataset(k, data=v)
+        for k, v in var2.items():
+            f.create_dataset(k, data=np.arange(v))
 
         if h5py.__version__ < LooseVersion('2.10.0'):
             f['foo2'].dims.create_scale(f['x1'])
@@ -648,70 +638,16 @@ def test_invalid_netcdf4_mixed(tmp_local_or_remote_netcdf):
     with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
                        phony_dims='sort') as ds:
         var = ds.variables
-        assert var['foo1'].dimensions[0] == 'y1'
-        assert var['foo1'].dimensions[1] == 'z1'
-        assert var['foo1'].dimensions[2] == 'phony_dim_3'
-        assert var['foo2'].dimensions[0] == 'x1'
-        assert var['foo2'].dimensions[1] == 'y1'
-        assert var['foo2'].dimensions[2] == 'z1'
-        assert var['foo3'].dimensions[0] == 'y1'
-        assert var['foo3'].dimensions[1] == 'z1'
-        assert var['foo3'].dimensions[2] == 'phony_dim_3'
-        assert var['foo4'].dimensions[0] == 'x1'
-        assert var['foo4'].dimensions[1] == 'y1'
-        assert var['foo4'].dimensions[2] == 'z1'
-
-        assert var['x'].dimensions[0] == 'y1'
-        assert var['y'].dimensions[0] == 'y1'
-        assert var['z'].dimensions[0] == 'y1'
-        assert var['x1'].dimensions[0] == 'x1'
-        assert var['y1'].dimensions[0] == 'y1'
-        assert var['z1'].dimensions[0] == 'z1'
+        check_invalid_netcdf4_mixed(var, 3)
 
     with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
                        phony_dims='access') as ds:
         var = ds.variables
-        assert var['foo1'].dimensions[0] == 'y1'
-        assert var['foo1'].dimensions[1] == 'z1'
-        assert var['foo1'].dimensions[2] == 'phony_dim_0'
-        assert var['foo2'].dimensions[0] == 'x1'
-        assert var['foo2'].dimensions[1] == 'y1'
-        assert var['foo2'].dimensions[2] == 'z1'
-        assert var['foo3'].dimensions[0] == 'y1'
-        assert var['foo3'].dimensions[1] == 'z1'
-        assert var['foo3'].dimensions[2] == 'phony_dim_0'
-        assert var['foo4'].dimensions[0] == 'x1'
-        assert var['foo4'].dimensions[1] == 'y1'
-        assert var['foo4'].dimensions[2] == 'z1'
-
-        assert var['x'].dimensions[0] == 'y1'
-        assert var['y'].dimensions[0] == 'y1'
-        assert var['z'].dimensions[0] == 'y1'
-        assert var['x1'].dimensions[0] == 'x1'
-        assert var['y1'].dimensions[0] == 'y1'
-        assert var['z1'].dimensions[0] == 'z1'
+        check_invalid_netcdf4_mixed(var, 0)
 
     with netCDF4.Dataset(tmp_local_or_remote_netcdf, 'r') as ds:
         var = ds.variables
-        assert var['foo1'].dimensions[0] == 'y1'
-        assert var['foo1'].dimensions[1] == 'z1'
-        assert var['foo1'].dimensions[2] == 'phony_dim_3'
-        assert var['foo2'].dimensions[0] == 'x1'
-        assert var['foo2'].dimensions[1] == 'y1'
-        assert var['foo2'].dimensions[2] == 'z1'
-        assert var['foo3'].dimensions[0] == 'y1'
-        assert var['foo3'].dimensions[1] == 'z1'
-        assert var['foo3'].dimensions[2] == 'phony_dim_3'
-        assert var['foo4'].dimensions[0] == 'x1'
-        assert var['foo4'].dimensions[1] == 'y1'
-        assert var['foo4'].dimensions[2] == 'z1'
-
-        assert var['x'].dimensions[0] == 'y1'
-        assert var['y'].dimensions[0] == 'y1'
-        assert var['z'].dimensions[0] == 'y1'
-        assert var['x1'].dimensions[0] == 'x1'
-        assert var['y1'].dimensions[0] == 'y1'
-        assert var['z1'].dimensions[0] == 'z1'
+        check_invalid_netcdf4_mixed(var, 3)
 
     with h5netcdf.File(tmp_local_or_remote_netcdf, 'r') as ds:
         with raises(ValueError):

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -521,12 +521,201 @@ def test_error_handling(tmp_local_or_remote_netcdf):
 def test_invalid_netcdf4(tmp_local_or_remote_netcdf):
     h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
     with h5.File(tmp_local_or_remote_netcdf, 'w') as f:
-        f.create_dataset('foo', data=np.arange(5))
-        # labeled dimensions but no dimension scales
-        f['foo'].dims[0].label = 'x'
+        grps = ['bar', 'baz']
+        foo_data = np.arange(125).reshape(5, 5, 5)
+        bar_data = np.arange(625).reshape(25, 5, 5)
+        var = {'foo1': foo_data, 'foo2': bar_data,
+               'foo3': foo_data, 'foo4': bar_data}
+        var2 = {'x': 5, 'y': 5, 'z': 5, 'x1': 25, 'y1': 5, 'z1': 5}
+        for grp in grps:
+            fx = f.create_group(grp)
+            for k, v in var.items():
+                fx.create_dataset(k, data=v)
+            for k, v in var2.items():
+                fx.create_dataset(k, data=np.arange(v))
+
+    with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
+                       phony_dims='sort') as dsr:
+        i = len(grps) - 1
+        for grp in grps[::-1]:
+            var = dsr[grp].variables
+            pdim = 'phony_dim_{}'
+            assert var['foo1'].dimensions[0] == pdim.format(i * 4)
+            assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
+            assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
+            assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
+            assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
+            assert var['foo3'].dimensions[0] == pdim.format(i * 4)
+            assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
+            assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
+            assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['foo4'].dimensions[1] == pdim.format(i * 4)
+            assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
+            assert var['x'].dimensions[0] == pdim.format(i * 4)
+            assert var['y'].dimensions[0] == pdim.format(i * 4)
+            assert var['z'].dimensions[0] == pdim.format(i * 4)
+            assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['y1'].dimensions[0] == pdim.format(i * 4)
+            assert var['z1'].dimensions[0] == pdim.format(i * 4)
+            i -= 1
+
+    with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
+                       phony_dims='access') as dsr:
+        for i, grp in enumerate(grps[::-1]):
+            var = dsr[grp].variables
+            pdim = 'phony_dim_{}'
+            assert var['foo1'].dimensions[0] == pdim.format(i * 4)
+            assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
+            assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
+            assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
+            assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
+            assert var['foo3'].dimensions[0] == pdim.format(i * 4)
+            assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
+            assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
+            assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['foo4'].dimensions[1] == pdim.format(i * 4)
+            assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
+            assert var['x'].dimensions[0] == pdim.format(i * 4)
+            assert var['y'].dimensions[0] == pdim.format(i * 4)
+            assert var['z'].dimensions[0] == pdim.format(i * 4)
+            assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['y1'].dimensions[0] == pdim.format(i * 4)
+            assert var['z1'].dimensions[0] == pdim.format(i * 4)
+
+    with netCDF4.Dataset(tmp_local_or_remote_netcdf, mode='r') as dsr:
+        for i, grp in enumerate(grps):
+            var = dsr[grp].variables
+            pdim = 'phony_dim_{}'
+            assert var['foo1'].dimensions[0] == pdim.format(i * 4)
+            assert var['foo1'].dimensions[1] == pdim.format(1 + i * 4)
+            assert var['foo1'].dimensions[2] == pdim.format(2 + i * 4)
+            assert var['foo2'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['foo2'].dimensions[1] == pdim.format(0 + i * 4)
+            assert var['foo2'].dimensions[2] == pdim.format(1 + i * 4)
+            assert var['foo3'].dimensions[0] == pdim.format(i * 4)
+            assert var['foo3'].dimensions[1] == pdim.format(1 + i * 4)
+            assert var['foo3'].dimensions[2] == pdim.format(2 + i * 4)
+            assert var['foo4'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['foo4'].dimensions[1] == pdim.format(i * 4)
+            assert var['foo4'].dimensions[2] == pdim.format(1 + i * 4)
+            assert var['x'].dimensions[0] == pdim.format(i * 4)
+            assert var['y'].dimensions[0] == pdim.format(i * 4)
+            assert var['z'].dimensions[0] == pdim.format(i * 4)
+            assert var['x1'].dimensions[0] == pdim.format(3 + i * 4)
+            assert var['y1'].dimensions[0] == pdim.format(i * 4)
+            assert var['z1'].dimensions[0] == pdim.format(i * 4)
+
     with h5netcdf.File(tmp_local_or_remote_netcdf, 'r') as ds:
         with raises(ValueError):
-            ds.variables['foo'].dimensions
+            ds['bar'].variables['foo1'].dimensions
+
+    with raises(ValueError):
+        with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
+                           phony_dims='srt') as ds:
+            pass
+
+
+def test_invalid_netcdf4_mixed(tmp_local_or_remote_netcdf):
+    h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
+    with h5.File(tmp_local_or_remote_netcdf) as f:
+        foo_data = np.arange(125).reshape(5, 5, 5)
+        bar_data = np.arange(625).reshape(25, 5, 5)
+        f.create_dataset('foo1', data=foo_data)
+        f.create_dataset('foo2', data=bar_data)
+        f.create_dataset('foo3', data=foo_data)
+        f.create_dataset('foo4', data=bar_data)
+        f.create_dataset('x', data=np.arange(5))
+        f.create_dataset('y', data=np.arange(5))
+        f.create_dataset('z', data=np.arange(5))
+        f.create_dataset('x1', data=np.arange(25))
+        f.create_dataset('y1', data=np.arange(5))
+        f.create_dataset('z1', data=np.arange(5))
+
+        if h5py.__version__ < LooseVersion('2.10.0'):
+            f['foo2'].dims.create_scale(f['x1'])
+            f['foo2'].dims.create_scale(f['y1'])
+            f['foo2'].dims.create_scale(f['z1'])
+        else:
+            f['x1'].make_scale()
+            f['y1'].make_scale()
+            f['z1'].make_scale()
+        f['foo2'].dims[0].attach_scale(f['x1'])
+        f['foo2'].dims[1].attach_scale(f['y1'])
+        f['foo2'].dims[2].attach_scale(f['z1'])
+
+    with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
+                       phony_dims='sort') as ds:
+        var = ds.variables
+        assert var['foo1'].dimensions[0] == 'y1'
+        assert var['foo1'].dimensions[1] == 'z1'
+        assert var['foo1'].dimensions[2] == 'phony_dim_3'
+        assert var['foo2'].dimensions[0] == 'x1'
+        assert var['foo2'].dimensions[1] == 'y1'
+        assert var['foo2'].dimensions[2] == 'z1'
+        assert var['foo3'].dimensions[0] == 'y1'
+        assert var['foo3'].dimensions[1] == 'z1'
+        assert var['foo3'].dimensions[2] == 'phony_dim_3'
+        assert var['foo4'].dimensions[0] == 'x1'
+        assert var['foo4'].dimensions[1] == 'y1'
+        assert var['foo4'].dimensions[2] == 'z1'
+
+        assert var['x'].dimensions[0] == 'y1'
+        assert var['y'].dimensions[0] == 'y1'
+        assert var['z'].dimensions[0] == 'y1'
+        assert var['x1'].dimensions[0] == 'x1'
+        assert var['y1'].dimensions[0] == 'y1'
+        assert var['z1'].dimensions[0] == 'z1'
+
+    with h5netcdf.File(tmp_local_or_remote_netcdf, 'r',
+                       phony_dims='access') as ds:
+        var = ds.variables
+        assert var['foo1'].dimensions[0] == 'y1'
+        assert var['foo1'].dimensions[1] == 'z1'
+        assert var['foo1'].dimensions[2] == 'phony_dim_0'
+        assert var['foo2'].dimensions[0] == 'x1'
+        assert var['foo2'].dimensions[1] == 'y1'
+        assert var['foo2'].dimensions[2] == 'z1'
+        assert var['foo3'].dimensions[0] == 'y1'
+        assert var['foo3'].dimensions[1] == 'z1'
+        assert var['foo3'].dimensions[2] == 'phony_dim_0'
+        assert var['foo4'].dimensions[0] == 'x1'
+        assert var['foo4'].dimensions[1] == 'y1'
+        assert var['foo4'].dimensions[2] == 'z1'
+
+        assert var['x'].dimensions[0] == 'y1'
+        assert var['y'].dimensions[0] == 'y1'
+        assert var['z'].dimensions[0] == 'y1'
+        assert var['x1'].dimensions[0] == 'x1'
+        assert var['y1'].dimensions[0] == 'y1'
+        assert var['z1'].dimensions[0] == 'z1'
+
+    with netCDF4.Dataset(tmp_local_or_remote_netcdf, 'r') as ds:
+        var = ds.variables
+        assert var['foo1'].dimensions[0] == 'y1'
+        assert var['foo1'].dimensions[1] == 'z1'
+        assert var['foo1'].dimensions[2] == 'phony_dim_3'
+        assert var['foo2'].dimensions[0] == 'x1'
+        assert var['foo2'].dimensions[1] == 'y1'
+        assert var['foo2'].dimensions[2] == 'z1'
+        assert var['foo3'].dimensions[0] == 'y1'
+        assert var['foo3'].dimensions[1] == 'z1'
+        assert var['foo3'].dimensions[2] == 'phony_dim_3'
+        assert var['foo4'].dimensions[0] == 'x1'
+        assert var['foo4'].dimensions[1] == 'y1'
+        assert var['foo4'].dimensions[2] == 'z1'
+
+        assert var['x'].dimensions[0] == 'y1'
+        assert var['y'].dimensions[0] == 'y1'
+        assert var['z'].dimensions[0] == 'y1'
+        assert var['x1'].dimensions[0] == 'x1'
+        assert var['y1'].dimensions[0] == 'y1'
+        assert var['z1'].dimensions[0] == 'z1'
+
+    with h5netcdf.File(tmp_local_or_remote_netcdf, 'r') as ds:
+        with raises(ValueError):
+            ds.variables['foo1'].dimensions
 
 
 def test_hierarchical_access_auto_create(tmp_local_or_remote_netcdf):
@@ -885,6 +1074,7 @@ def test_reading_unused_unlimited_dimension(tmp_local_or_remote_netcdf):
         assert f.dimensions == {'x': None}
 
     f = h5netcdf.File(tmp_local_or_remote_netcdf, 'r')
+
 
 def test_reading_special_datatype_created_with_c_api(tmp_local_netcdf):
     "Test reading a file with unsupported Datatype"


### PR DESCRIPTION
This PR adds naming for unlabeled dimensions (without dimension scales) in a netcdf style manner (`phony_dim_0` etc) instead of raising an error. 

This works nice in most cases (hdf5 files with no dimension scales at all). In mixing cases the naming might need improvement. ~~I did not find a way of having an overall count of the invented `phony_dim_N`, so with the proposed changes it the counting is per dataset/subgroup~~.

Xref: https://github.com/shoyer/h5netcdf/issues/43