### PR TITLE
FIX: only add h5py.Dataset to variables

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -261,10 +261,11 @@ class Group(Mapping):
 
                     self._dim_order[k] = dim_id
                 if not _netcdf_dimension_but_not_variable(v):
-                    var_name = k
-                    if k.startswith('_nc4_non_coord_'):
-                        var_name = k[len('_nc4_non_coord_'):]
-                    self._variables.add(var_name)
+                    if isinstance(v, h5py.Dataset):
+                        var_name = k
+                        if k.startswith('_nc4_non_coord_'):
+                            var_name = k[len('_nc4_non_coord_'):]
+                        self._variables.add(var_name)
 
         self._initialized = True
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -880,3 +880,11 @@ def test_reading_unused_unlimited_dimension(tmp_local_or_remote_netcdf):
         assert f.dimensions == {'x': None}
 
     f = h5netcdf.File(tmp_local_or_remote_netcdf, 'r')
+
+def test_reading_special_datatype_created_with_c_api(tmp_local_netcdf):
+    "Test reading a file with unsupported Datatype"
+    with netCDF4.Dataset(tmp_local_netcdf, "w") as f:
+        complex128 = np.dtype([('real', np.float64), ('imag', np.float64)])
+        f.createCompoundType(complex128, 'complex128')
+    with h5netcdf.File(tmp_local_netcdf) as f:
+        pass


### PR DESCRIPTION
As suggested in #49 adds another check to only add h5py.Dataset to variables.

fixes #49
fixes #63
