### PR TITLE
FIX: install correct h5pyd version, use request.config in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ notifications:
 
 matrix:
   include:
-  - env: PYTHON_VERSION=3.5
-  - env: PYTHON_VERSION=3.6
-  - env: PYTHON_VERSION=3.7
+  - env: PYTHON_VERSION=3.5 H5PYD_VERSION=v0.5.0
+  - env: PYTHON_VERSION=3.6 H5PYD_VERSION=v0.6.0
+  - env: PYTHON_VERSION=3.7 H5PYD_VERSION=v0.6.0
 
 before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -25,7 +25,7 @@ install:
   - curl ${HS_ENDPOINT}/about && export WITHRESTAPI=--restapi
   - if [ -n "${WITHRESTAPI}" ]; then
       pip install requests pytz ;
-      pip install git+https://github.com/HDFGroup/h5pyd.git ;
+      pip install git+https://github.com/HDFGroup/h5pyd.git@${H5PYD_VERSION} ;
       export H5PYD_TEST_FOLDER=${TEST_BASE_DIR}/h5pyd_test/${PYTHON_VERSION} ;
     fi
   - conda list

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -36,7 +36,7 @@ def tmp_local_netcdf(tmpdir):
 @pytest.fixture(params=['testfile.nc', 'hdf5://testfile'])
 def tmp_local_or_remote_netcdf(request, tmpdir):
     if request.param.startswith(remote_h5):
-        if not pytest.config.option.restapi:
+        if not request.config.option.restapi:
             pytest.skip('Do not test with HDF5 REST API')
         elif without_h5pyd:
             pytest.skip('h5pyd package not available')


### PR DESCRIPTION
fixes #61

fixes new issue installing incompatible h5pyd version for Python3.5
